### PR TITLE
[modify] update version to 4

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -12,7 +12,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
       - name: Install dependencies


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows to use the latest version of the `setup-node` action. This change ensures that the workflows are using the most recent features and fixes provided by the action.

Updates to GitHub Actions workflows:

* [`.github/workflows/build-and-publish.yml`](diffhunk://#diff-c58efb7d239ba7eb89123ff4b9e3117bd84c382787283c3f149cf0c4620d7029L15-R15): Updated `setup-node` action from version 2 to version 4.
* [`.github/workflows/lint-and-test.yml`](diffhunk://#diff-9a979a1e38ba79e2c75e54c4bf21fe1a2a1b935e1736666565f992e634dadd0fL10-R10): Updated `setup-node` action from version 2 to version 4.